### PR TITLE
An alternate tty reading routine

### DIFF
--- a/lib/Term/ExtendedColor/Xresources.pm
+++ b/lib/Term/ExtendedColor/Xresources.pm
@@ -52,16 +52,18 @@ sub get_xterm_colors {
     print "\e]4;$i;?\a"; # the '?' indicates a query
 
     my $response = '';
-    $response .= ReadKey(0, $tty) for(0 .. 22);
-
+    my ($r, $g, $b);
+    while(1) {
+        if ($response =~ m[ rgb: (.{4}) / (.{4}) / (.{4}) ]x) {
+            ($r, $g, $b) = map { substr $_, 0, 2 } ($1, $2, $3);
+            last;
+        }
+        else {
+            $response .= ReadKey(0, $tty);
+        }
+    }
 
     ReadMode('normal');
-
-    my($r, $g, $b) = $response =~ m{
-      rgb: ([A-Za-z0-9]{2}).*/
-           ([A-Za-z0-9]{2}).*/
-           ([A-Za-z0-9]{2})
-       }x;
 
     $colors->{$i}->{raw} = $response;
     # Return in base 10 by default


### PR DESCRIPTION
Do you mind testing this? The current implementation does not work on my system. The color lookup response is
"\a\e]4;xxx;rgb:rrrr/gggg/bbbb" (max 27 characters, with each RGB
value duplicated). Since we only grab 23, this isn't enough and
many of the color lookups fail. Additionally the module causes the
TTY to spew some output to the user, and requires a 'reset' for the terminal to function afterwards.

Changing 23 to 26 causes the tty to hang. So instead we replace
it with a loop that reads until the full response has been read.

It may be that the .{4} needs to be .{2,4} to be compatible with some terminals.
